### PR TITLE
Usb tx latency

### DIFF
--- a/hadoucan-fw/src/CAN_USB_app_config.cpp
+++ b/hadoucan-fw/src/CAN_USB_app_config.cpp
@@ -555,26 +555,26 @@ bool CAN_USB_app_config::from_xml(const tinyxml2::XMLDocument& config_doc)
 	}
 
 	{
-		const tinyxml2::XMLElement* debug_element = config_root->FirstChildElement("debug");
-		if(debug_element == nullptr)
+		const tinyxml2::XMLElement* timeout_element = config_root->FirstChildElement("timeout");
+		if(timeout_element == nullptr)
 		{
-			logger->log(LOG_LEVEL::ERROR, "CAN_USB_app", "config.xml: could not find element debug");
+			logger->log(LOG_LEVEL::ERROR, "CAN_USB_app", "config.xml: could not find element timeout");
 			return false;
 		}
 
-		if(!get_uint_text(debug_element, "usb_tx_delay", &m_config.usb_tx_delay))
+		if(!get_uint_text(timeout_element, "usb_tx_delay", &m_config.usb_tx_delay))
 		{
 			logger->log(LOG_LEVEL::ERROR, "CAN_USB_app", "config.xml: could not find element timeout/usb_tx_delay");
 			return false;
 		}
 
-		if(!get_uint_text(debug_element, "can_rx_poll_interval", &m_config.can_rx_poll_interval))
+		if(!get_uint_text(timeout_element, "can_rx_poll_interval", &m_config.can_rx_poll_interval))
 		{
 			logger->log(LOG_LEVEL::ERROR, "CAN_USB_app", "config.xml: could not find element timeout/can_rx_poll_interval");
 			return false;
 		}
 
-		if(!get_uint_text(debug_element, "can_rx_isr_watermark", &m_config.can_rx_isr_watermark))
+		if(!get_uint_text(timeout_element, "can_rx_isr_watermark", &m_config.can_rx_isr_watermark))
 		{
 			logger->log(LOG_LEVEL::ERROR, "CAN_USB_app", "config.xml: could not find element timeout/can_rx_isr_watermark");
 			return false;

--- a/hadoucan-fw/src/CAN_USB_app_config.cpp
+++ b/hadoucan-fw/src/CAN_USB_app_config.cpp
@@ -253,21 +253,21 @@ bool CAN_USB_app_config::to_xml(tinyxml2::XMLDocument* const config_doc) const
 		config_doc_root->InsertEndChild(timeout);
 
 		tinyxml2::XMLComment* comment = config_doc->NewComment("Set usb_tx_delay to number of ms to wait for full USB packet");
-		config_doc_root->InsertEndChild(comment);
+		timeout->InsertEndChild(comment);
 
 		node = config_doc->NewElement("usb_tx_delay");
 		node->SetText(m_config.usb_tx_delay);
 		timeout->InsertEndChild(node);
 
 		comment = config_doc->NewComment("Set can_rx_poll_interval number of ms to check for can packets in fifo under the watermark");
-		config_doc_root->InsertEndChild(comment);
+		timeout->InsertEndChild(comment);
 
 		node = config_doc->NewElement("can_rx_poll_interval");
 		node->SetText(m_config.can_rx_poll_interval);
 		timeout->InsertEndChild(node);
 
 		comment = config_doc->NewComment("Set can_rx_isr_watermark to number of can packets to collect in the CAN controller ram before triggering isr");
-		config_doc_root->InsertEndChild(comment);
+		timeout->InsertEndChild(comment);
 
 		node = config_doc->NewElement("can_rx_isr_watermark");
 		node->SetText(m_config.can_rx_isr_watermark);

--- a/hadoucan-fw/src/CAN_USB_app_config.cpp
+++ b/hadoucan-fw/src/CAN_USB_app_config.cpp
@@ -41,6 +41,7 @@ void CAN_USB_app_config::set_defualt()
 	m_config.uart_baud = 921600U;
 
 	m_config.usb_tx_delay         = 50;
+	m_config.usb_tx_pkt_watermark = 512;
 	m_config.can_rx_poll_interval = 50;
 	m_config.can_rx_isr_watermark = 16;
 }
@@ -257,6 +258,13 @@ bool CAN_USB_app_config::to_xml(tinyxml2::XMLDocument* const config_doc) const
 
 		node = config_doc->NewElement("usb_tx_delay");
 		node->SetText(m_config.usb_tx_delay);
+		timeout->InsertEndChild(node);
+
+		comment = config_doc->NewComment("Set usb_tx_pkt_watermark to number of bytes to try and send in one USB packet, for FS try 64, for HS try 512.");
+		timeout->InsertEndChild(comment);
+
+		node = config_doc->NewElement("usb_tx_pkt_watermark");
+		node->SetText(m_config.usb_tx_pkt_watermark);
 		timeout->InsertEndChild(node);
 
 		comment = config_doc->NewComment("Set can_rx_poll_interval number of ms to check for can packets in fifo under the watermark");
@@ -565,6 +573,12 @@ bool CAN_USB_app_config::from_xml(const tinyxml2::XMLDocument& config_doc)
 		if(!get_uint_text(timeout_element, "usb_tx_delay", &m_config.usb_tx_delay))
 		{
 			logger->log(LOG_LEVEL::ERROR, "CAN_USB_app", "config.xml: could not find element timeout/usb_tx_delay");
+			return false;
+		}
+
+		if(!get_uint_text(timeout_element, "usb_tx_pkt_watermark", &m_config.usb_tx_pkt_watermark))
+		{
+			logger->log(LOG_LEVEL::ERROR, "CAN_USB_app", "config.xml: could not find element timeout/usb_tx_pkt_watermark");
 			return false;
 		}
 

--- a/hadoucan-fw/src/CAN_USB_app_config.cpp
+++ b/hadoucan-fw/src/CAN_USB_app_config.cpp
@@ -39,6 +39,8 @@ void CAN_USB_app_config::set_defualt()
 
 	m_config.log_level = freertos_util::logging::LOG_LEVEL::INFO;
 	m_config.uart_baud = 921600U;
+
+	m_config.usb_tx_delay = 50;
 }
 
 bool CAN_USB_app_config::to_xml(tinyxml2::XMLDocument* const config_doc) const
@@ -241,6 +243,15 @@ bool CAN_USB_app_config::to_xml(tinyxml2::XMLDocument* const config_doc) const
 
 		node = config_doc->NewElement("uart_baud");
 		node->SetText(m_config.uart_baud);
+		debug->InsertEndChild(node);
+	}
+
+	{
+		tinyxml2::XMLElement* timeout = config_doc->NewElement("timeout");
+		config_doc_root->InsertEndChild(debug);
+
+		node = config_doc->NewElement("usb_tx_delay");
+		node->SetText(freertos_util::logging::LOG_LEVEL_to_str(m_config.usb_tx_delay));
 		debug->InsertEndChild(node);
 	}
 
@@ -520,6 +531,21 @@ bool CAN_USB_app_config::from_xml(const tinyxml2::XMLDocument& config_doc)
 		if(!get_uint_text(debug_element, "uart_baud", &m_config.uart_baud))
 		{
 			logger->log(LOG_LEVEL::ERROR, "CAN_USB_app", "config.xml: could not find element debug/uart_baud");
+			return false;
+		}
+	}
+
+	{
+		const tinyxml2::XMLElement* debug_element = config_root->FirstChildElement("debug");
+		if(debug_element == nullptr)
+		{
+			logger->log(LOG_LEVEL::ERROR, "CAN_USB_app", "config.xml: could not find element debug");
+			return false;
+		}
+
+		if(!get_uint_text(debug_element, "usb_tx_delay", &m_config.usb_tx_delay))
+		{
+			logger->log(LOG_LEVEL::ERROR, "CAN_USB_app", "config.xml: could not find element timeout/usb_tx_delay");
 			return false;
 		}
 	}

--- a/hadoucan-fw/src/CAN_USB_app_config.cpp
+++ b/hadoucan-fw/src/CAN_USB_app_config.cpp
@@ -250,28 +250,28 @@ bool CAN_USB_app_config::to_xml(tinyxml2::XMLDocument* const config_doc) const
 
 	{
 		tinyxml2::XMLElement* timeout = config_doc->NewElement("timeout");
-		config_doc_root->InsertEndChild(debug);
+		config_doc_root->InsertEndChild(timeout);
 
 		tinyxml2::XMLComment* comment = config_doc->NewComment("Set usb_tx_delay to number of ms to wait for full USB packet");
 		config_doc_root->InsertEndChild(comment);
 
 		node = config_doc->NewElement("usb_tx_delay");
-		node->SetText(freertos_util::logging::LOG_LEVEL_to_str(m_config.usb_tx_delay));
-		debug->InsertEndChild(node);
+		node->SetText(m_config.usb_tx_delay);
+		timeout->InsertEndChild(node);
 
 		comment = config_doc->NewComment("Set can_rx_poll_interval number of ms to check for can packets in fifo under the watermark");
 		config_doc_root->InsertEndChild(comment);
 
 		node = config_doc->NewElement("can_rx_poll_interval");
-		node->SetText(freertos_util::logging::LOG_LEVEL_to_str(m_config.can_rx_poll_interval));
-		debug->InsertEndChild(node);
+		node->SetText(m_config.can_rx_poll_interval);
+		timeout->InsertEndChild(node);
 
 		comment = config_doc->NewComment("Set can_rx_isr_watermark to number of can packets to collect in the CAN controller ram before triggering isr");
 		config_doc_root->InsertEndChild(comment);
 
 		node = config_doc->NewElement("can_rx_isr_watermark");
-		node->SetText(freertos_util::logging::LOG_LEVEL_to_str(m_config.can_rx_isr_watermark));
-		debug->InsertEndChild(node);
+		node->SetText(m_config.can_rx_isr_watermark);
+		timeout->InsertEndChild(node);
 	}
 
 	return true;

--- a/hadoucan-fw/src/CAN_USB_app_config.hpp
+++ b/hadoucan-fw/src/CAN_USB_app_config.hpp
@@ -65,6 +65,7 @@ public:
 		unsigned uart_baud;
 
 		unsigned usb_tx_delay;
+		unsigned usb_tx_pkt_watermark;
 		unsigned can_rx_poll_interval;
 		unsigned can_rx_isr_watermark;
 	};

--- a/hadoucan-fw/src/CAN_USB_app_config.hpp
+++ b/hadoucan-fw/src/CAN_USB_app_config.hpp
@@ -63,6 +63,8 @@ public:
 
 		freertos_util::logging::LOG_LEVEL log_level;
 		unsigned uart_baud;
+
+		unsigned usb_tx_delay;
 	};
 
 	static Config_Set get_defualt()

--- a/hadoucan-fw/src/CAN_USB_app_config.hpp
+++ b/hadoucan-fw/src/CAN_USB_app_config.hpp
@@ -65,6 +65,8 @@ public:
 		unsigned uart_baud;
 
 		unsigned usb_tx_delay;
+		unsigned can_rx_poll_interval;
+		unsigned can_rx_isr_watermark;
 	};
 
 	static Config_Set get_defualt()

--- a/hadoucan-fw/src/STM32_fdcan_tx.cpp
+++ b/hadoucan-fw/src/STM32_fdcan_tx.cpp
@@ -2,6 +2,7 @@
 
 #include "lawicel/STM32_FDCAN_DLC.hpp"
 
+#include "CAN_USB_app_config.hpp"
 #include "global_app_inst.hpp"
 
 #include "main.h"
@@ -408,8 +409,14 @@ bool STM32_fdcan_tx::init()
 		return false;
 	}
 
+	unsigned can_rx_isr_watermark = 16;
+	{
+		std::unique_lock<Mutex_static_recursive> lock;
+		can_rx_isr_watermark = can_usb_app.get_config(&lock).can_rx_isr_watermark;
+	}
+
 	logger->log(LOG_LEVEL::TRACE, "STM32_fdcan_tx::init", "HAL_FDCAN_ConfigFifoWatermark");
-	ret = HAL_FDCAN_ConfigFifoWatermark(m_fdcan_handle, FDCAN_CFG_RX_FIFO0, 16);
+	ret = HAL_FDCAN_ConfigFifoWatermark(m_fdcan_handle, FDCAN_CFG_RX_FIFO0, can_rx_isr_watermark);
 	if(ret != HAL_OK)
 	{
 		logger->log(LOG_LEVEL::ERROR, "STM32_fdcan_tx::init", "HAL_FDCAN_ConfigFifoWatermark for FIFO0 failed");

--- a/hadoucan-fw/src/STM32_fdcan_tx.hpp
+++ b/hadoucan-fw/src/STM32_fdcan_tx.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "CAN_USB_app_config.hpp"
 #include "CAN_USB_app_bitrate_table.hpp"
 
 #include "stm32h7xx_hal.h"

--- a/hadoucan-fw/src/lawicel/Lawicel_parser_stm32.cpp
+++ b/hadoucan-fw/src/lawicel/Lawicel_parser_stm32.cpp
@@ -404,7 +404,7 @@ bool Lawicel_parser_stm32::handle_get_version(std::array<uint8_t, 4>* const ver)
 	logger->log(LOG_LEVEL::DEBUG, "Lawicel_parser_stm32::handle_get_version", "");
 
 	const std::array<char, 2> hw_ver = {'0', '1'};
-	const std::array<char, 2> sw_ver = {'0', 'A'};
+	const std::array<char, 2> sw_ver = {'0', 'B'};
 	
 	ver->data()[0] = static_cast<uint8_t>(hw_ver[0]);
 	ver->data()[1] = static_cast<uint8_t>(hw_ver[1]);

--- a/hadoucan-fw/src/tasks/STM32_fdcan_rx.cpp
+++ b/hadoucan-fw/src/tasks/STM32_fdcan_rx.cpp
@@ -238,6 +238,12 @@ void STM32_fdcan_rx::work()
 	std::string packet_str;
 	packet_str.reserve(1+8+128+4+1);
 
+	m_can_rx_poll_interval = 16;
+	{
+		std::unique_lock<Mutex_static_recursive> lock;
+		m_can_rx_poll_interval = can_usb_app.get_config(&lock).can_rx_poll_interval;
+	}
+
 	for(;;)
 	{
 		//if the fifo is empty, wait for the watermark interrupt or a timeout
@@ -248,7 +254,7 @@ void STM32_fdcan_rx::work()
 			const uint32_t fifo0_depth = HAL_FDCAN_GetRxFifoFillLevel(m_fdcan_handle, FDCAN_RX_FIFO0);
 			if(fifo0_depth == 0)
 			{
-				queue_set_pk = m_can_fd_queue.pop_front(&pk, pdMS_TO_TICKS(50));
+				queue_set_pk = m_can_fd_queue.pop_front(&pk, pdMS_TO_TICKS(m_can_rx_poll_interval));
 			}
 		}
 

--- a/hadoucan-fw/src/tasks/STM32_fdcan_rx.hpp
+++ b/hadoucan-fw/src/tasks/STM32_fdcan_rx.hpp
@@ -82,4 +82,6 @@ protected:
 
 	std::atomic_bool m_can_fifo1_full;
 	std::atomic_uint m_can_fifo1_msg_lost;
+
+	unsigned m_can_rx_poll_interval;
 };

--- a/hadoucan-fw/src/tasks/USB_tx_buffer_task.cpp
+++ b/hadoucan-fw/src/tasks/USB_tx_buffer_task.cpp
@@ -3,6 +3,9 @@
 #include "freertos_cpp_util/logging/Global_logger.hpp"
 
 #include "CAN_USB_app_config.hpp"
+#include "global_app_inst.hpp"
+
+#include "freertos_cpp_util/Mutex_static_recursive.hpp"
 
 constexpr size_t USB_tx_buffer_task::BUFFER_HIGH_WATERMARK;
 

--- a/hadoucan-fw/src/tasks/USB_tx_buffer_task.cpp
+++ b/hadoucan-fw/src/tasks/USB_tx_buffer_task.cpp
@@ -2,6 +2,8 @@
 
 #include "freertos_cpp_util/logging/Global_logger.hpp"
 
+#include "CAN_USB_app_config.hpp"
+
 constexpr size_t USB_tx_buffer_task::BUFFER_HIGH_WATERMARK;
 
 constexpr uint32_t USB_tx_buffer_task::USB_HS_PACKET_WAIT_MS;
@@ -15,6 +17,13 @@ void USB_tx_buffer_task::work()
 	m_packet_buf.reserve(512);
 
 	std::function<bool(void)> has_buffer_pred = std::bind(&USB_tx_buffer_task::has_buffer, this);
+
+
+	unsigned usb_tx_delay = 50;
+	{
+		std::unique_lock<Mutex_static_recursive> lock;
+		usb_tx_delay = can_usb_app.get_config(&lock).usb_tx_delay;
+	}
 
 	for(;;)
 	{

--- a/hadoucan-fw/src/tasks/USB_tx_buffer_task.cpp
+++ b/hadoucan-fw/src/tasks/USB_tx_buffer_task.cpp
@@ -6,8 +6,6 @@
 
 constexpr size_t USB_tx_buffer_task::BUFFER_HIGH_WATERMARK;
 
-constexpr uint32_t USB_tx_buffer_task::USB_HS_PACKET_WAIT_MS;
-
 void USB_tx_buffer_task::work()
 {
 	freertos_util::logging::Logger* const logger = freertos_util::logging::Global_logger::get();
@@ -31,7 +29,7 @@ void USB_tx_buffer_task::work()
 
 		{
 			std::unique_lock<Mutex_static> lock(m_tx_buf_mutex);
-			m_tx_buf_condvar.wait_for(lock, std::chrono::milliseconds(USB_HS_PACKET_WAIT_MS), std::cref(has_buffer_pred));
+			m_tx_buf_condvar.wait_for(lock, std::chrono::milliseconds(usb_tx_delay), std::cref(has_buffer_pred));
 			
 			//might be empty if timed out
 			if(!m_tx_buf.empty())

--- a/hadoucan-fw/src/tasks/USB_tx_buffer_task.hpp
+++ b/hadoucan-fw/src/tasks/USB_tx_buffer_task.hpp
@@ -112,8 +112,6 @@ protected:
 		return false;
 	}
 
-	static constexpr uint32_t USB_HS_PACKET_WAIT_MS = 50;
-
 	std::deque<uint8_t> m_tx_buf;
 	Mutex_static m_tx_buf_mutex;
 	Condition_variable m_tx_buf_condvar;

--- a/hadoucan-fw/src/tasks/USB_tx_buffer_task.hpp
+++ b/hadoucan-fw/src/tasks/USB_tx_buffer_task.hpp
@@ -23,6 +23,9 @@ public:
 	USB_tx_buffer_task()
 	{
 		m_usb_driver = nullptr;
+
+		m_usb_tx_pkt_watermark = 512;
+		m_usb_tx_delay         = 50;
 	}
 
 	void set_usb_driver(usb_driver_base* const usb_driver)
@@ -103,9 +106,9 @@ protected:
 			return false;
 		}
 
-		if(m_tx_buf.size() >= 512)
+		if(m_tx_buf.size() >= m_usb_tx_pkt_watermark)
 		{
-			//yay, full USB HS packet
+			//yay, we have a watermarks worth of data
 			return true;
 		}
 
@@ -116,6 +119,10 @@ protected:
 	Mutex_static m_tx_buf_mutex;
 	Condition_variable m_tx_buf_condvar;
 	Condition_variable m_tx_buf_drain_condvar;
+
+	//params
+	unsigned m_usb_tx_pkt_watermark;
+	unsigned m_usb_tx_delay;
 
 	usb_driver_base* m_usb_driver;
 };


### PR DESCRIPTION
Add tunables for latency / throughput tradeoff

usb_tx_delay - number of ms to wait for a full usb packet
usb_tx_pkt_watermark  - number of bytes in a full usb packet
can_rx_poll_interval - number of ms to wait before polling can memory
can_rx_isr_watermark - number of packets in can memory before triggering isr